### PR TITLE
lots more goodies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
     from distutils.core import setup
 
 setup(name='aio-s3',
-      version='0.2',
+      version='0.3',
       description='Asyncio-based client for S3',
       author='Paul Colomiets',
       author_email='paul@colomiets.name',


### PR DESCRIPTION
- removed v2 signature support since v4 is now supported on all APIs
  across all regions
- added logging support
- added ability to add multipart chunks out of order
- collapsed Request class in to Bucket._request
- added retry logic as the AWS APIs are really finicky.
- collapsed error checking / data loading into Bucket._request
- added “scheme” support to fix the port ugliness for https, plus https
  can be on ports other than 443
- updated keep alive to keep AWS happy
- moved getLocation to Bucket
- simplified header logic
- switched error to also use xmltodict
