### PR TITLE
fix for buckets with "." in their name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
     from distutils.core import setup
 
 setup(name='aio-s3',
-      version='0.4.0',
+      version='0.4.1',
       description='Asyncio-based client for S3',
       author='Paul Colomiets',
       author_email='paul@colomiets.name',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
     from distutils.core import setup
 
 setup(name='aio-s3',
-      version='0.4.1',
+      version='0.4.2',
       description='Asyncio-based client for S3',
       author='Paul Colomiets',
       author_email='paul@colomiets.name',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='aio-s3',
       packages=[
           'aios3',
       ],
-      requires=['aiohttp', 'xmltodict'],
+      requires=['aiohttp', 'botocore', 'xmltodict'],
       classifiers=[
           'Development Status :: 4 - Beta',
           'Programming Language :: Python :: 3',


### PR DESCRIPTION
- switches to use botocore’s auth module so we’re not
  replicating/maintaining signing methods
- switches to path style API calls to support buckets with names
- gets rid of port parameter since s3 does not listen on ports besides
  80/443.
